### PR TITLE
feat: use WebSocket for commands and real-time state updates

### DIFF
--- a/custom_components/evonic/__init__.py
+++ b/custom_components/evonic/__init__.py
@@ -33,6 +33,9 @@ async def async_reload_entry(hass, entry):
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    coordinator: EvonicCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.stop_ws_listener()
+
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         del hass.data[DOMAIN][entry.entry_id]
 

--- a/custom_components/evonic/__init__.py
+++ b/custom_components/evonic/__init__.py
@@ -10,6 +10,7 @@ from .coordinator import EvonicCoordinator
 PLATFORMS = (
     Platform.LIGHT,
     Platform.CLIMATE,
+    Platform.NUMBER,
     Platform.SENSOR,
 )
 

--- a/custom_components/evonic/coordinator.py
+++ b/custom_components/evonic/coordinator.py
@@ -1,3 +1,8 @@
+import asyncio
+import json
+
+import aiohttp
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
@@ -15,6 +20,7 @@ class EvonicCoordinator(DataUpdateCoordinator[EvonicDevice]):
         self.evonic = Evonic(
             entry.data[CONF_HOST], session=async_get_clientsession(hass)
         )
+        self._ws_task: asyncio.Task | None = None
         super().__init__(hass, LOGGER, name=DOMAIN, update_interval=SCAN_INTERVAL)
 
     async def _async_update_data(self) -> EvonicDevice:
@@ -25,4 +31,51 @@ class EvonicCoordinator(DataUpdateCoordinator[EvonicDevice]):
         except Exception as error:
             raise UpdateFailed(f"Unexpected error communicating with Evonic device: {error}") from error
 
+        self._ensure_ws_listener()
         return device
+
+    def _ensure_ws_listener(self):
+        """Start the WebSocket listener if not already running."""
+        if self._ws_task is None or self._ws_task.done():
+            self._ws_task = self.hass.async_create_task(self._ws_listener())
+
+    async def _ws_listener(self):
+        """Background task: listen for real-time state pushes over WebSocket."""
+        while True:
+            try:
+                await self.evonic._ws_connect()
+                LOGGER.debug("WebSocket listener active on %s:81", self.evonic.host)
+                await self.evonic._ws_send("cmd", "get modules")
+
+                while self.evonic._ws is not None and not self.evonic._ws.closed:
+                    msg = await self.evonic._ws.receive()
+
+                    if msg.type == aiohttp.WSMsgType.TEXT:
+                        try:
+                            data = json.loads(msg.data)
+                            if self.data is not None:
+                                self.data.update_from_dict(data)
+                                self.async_set_updated_data(self.data)
+                        except json.JSONDecodeError:
+                            pass
+                    elif msg.type in (
+                        aiohttp.WSMsgType.CLOSED,
+                        aiohttp.WSMsgType.ERROR,
+                        aiohttp.WSMsgType.CLOSING,
+                    ):
+                        LOGGER.debug("WebSocket disconnected, will reconnect")
+                        self.evonic._ws = None
+                        break
+
+            except asyncio.CancelledError:
+                raise
+            except Exception as err:
+                LOGGER.debug("WebSocket listener error: %s", err)
+                self.evonic._ws = None
+
+            await asyncio.sleep(5)
+
+    def stop_ws_listener(self):
+        """Cancel the WebSocket listener task."""
+        if self._ws_task is not None and not self._ws_task.done():
+            self._ws_task.cancel()

--- a/custom_components/evonic/coordinator.py
+++ b/custom_components/evonic/coordinator.py
@@ -46,6 +46,7 @@ class EvonicCoordinator(DataUpdateCoordinator[EvonicDevice]):
                 await self.evonic._ws_connect()
                 LOGGER.debug("WebSocket listener active on %s:81", self.evonic.host)
                 await self.evonic._ws_send("cmd", "get modules")
+                await self.evonic._ws_send("cmd", "get effectList")
 
                 while self.evonic._ws is not None and not self.evonic._ws.closed:
                     msg = await self.evonic._ws.receive()

--- a/custom_components/evonic/light.py
+++ b/custom_components/evonic/light.py
@@ -7,7 +7,9 @@ from .coordinator import EvonicCoordinator
 from .const import DOMAIN
 from .models import EvonicEntity
 from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
     ATTR_EFFECT,
+    ATTR_RGB_COLOR,
     ColorMode,
     LightEntity,
     LightEntityFeature,
@@ -108,6 +110,150 @@ class EvonicFireLight(EvonicEntity, LightEntity):
         await self.coordinator.async_request_refresh()
 
 
+_ZONE_CONFIG = {
+    "flame": {
+        "name": "Flame Light",
+        "icon": "mdi:fire",
+        "brightness_attr": "flame_brightness",
+        "effect_attr": "flame_effect",
+        "effects_attr": "flame_effects",
+        "zone_param": "flame",
+        "module_key": "rgb0",
+    },
+    "top": {
+        "name": "Log Light",
+        "icon": "mdi:pine-tree",
+        "brightness_attr": "top_brightness",
+        "effect_attr": "top_effect",
+        "effects_attr": "top_effects",
+        "zone_param": "top",
+        "module_key": "rgb1",
+    },
+    "ember": {
+        "name": "FuelBed Light",
+        "icon": "mdi:fireplace",
+        "brightness_attr": "ember_brightness",
+        "effect_attr": "ember_effect",
+        "effects_attr": "ember_effects",
+        "zone_param": "ember",
+        "module_key": "rgb2",
+    },
+}
+
+
+class EvonicZoneLight(EvonicEntity, LightEntity):
+    """Per-zone lighting control (Flame, Log, or FuelBed)."""
+
+    _attr_color_mode = ColorMode.RGB
+    _attr_supported_color_modes = {ColorMode.RGB}
+    _attr_supported_features = LightEntityFeature.EFFECT
+
+    def __init__(self, coordinator: EvonicCoordinator, zone: str) -> None:
+        super().__init__(coordinator=coordinator)
+        cfg = _ZONE_CONFIG[zone]
+        self._zone = zone
+        self._zone_param = cfg["zone_param"]
+        self._brightness_attr = cfg["brightness_attr"]
+        self._effect_attr = cfg["effect_attr"]
+        self._effects_attr = cfg["effects_attr"]
+        self._color_attr = f"{cfg['zone_param']}_color"
+        self._effect_prefix = f"{cfg['zone_param'].capitalize()}_"
+        self._attr_name = cfg["name"]
+        self._attr_icon = cfg["icon"]
+        self._attr_unique_id = f"{coordinator.data.info.ssdp}_{zone}_zone_light"
+
+    @staticmethod
+    def _display_effect(name: str) -> str:
+        """Map internal effect names to display names."""
+        return "Colour" if name == "Color" else name
+
+    @staticmethod
+    def _internal_effect(name: str) -> str:
+        """Map display names back to internal effect names."""
+        return "Color" if name == "Colour" else name
+
+    @property
+    def available(self) -> bool:
+        return super().available and bool(self.coordinator.data.info.on)
+
+    @property
+    def brightness(self) -> int | None:
+        return getattr(self.coordinator.data.light, self._brightness_attr, None)
+
+    @property
+    def rgb_color(self) -> tuple[int, int, int] | None:
+        hex_color = getattr(self.coordinator.data.light, self._color_attr, None)
+        if not hex_color or len(hex_color) < 6:
+            return None
+        try:
+            return (
+                int(hex_color[0:2], 16),
+                int(hex_color[2:4], 16),
+                int(hex_color[4:6], 16),
+            )
+        except ValueError:
+            return None
+
+    @property
+    def is_on(self) -> bool:
+        if not self.coordinator.data.info.on:
+            return False
+        b = self.brightness
+        return b is not None and b > 0
+
+    @property
+    def effect(self) -> str | None:
+        raw = getattr(self.coordinator.data.light, self._effect_attr, None)
+        if raw and raw.startswith(self._effect_prefix):
+            return self._display_effect(raw[len(self._effect_prefix):])
+        return raw
+
+    @property
+    def effect_list(self) -> list[str] | None:
+        effects = getattr(self.coordinator.data.effects, self._effects_attr, None)
+        if not effects:
+            return None
+        return [
+            self._display_effect(
+                e[len(self._effect_prefix):] if e.startswith(self._effect_prefix) else e
+            )
+            for e in effects
+        ]
+
+    async def async_turn_on(self, **kwargs) -> None:
+        current_effect = getattr(self.coordinator.data.light, self._effect_attr, None)
+
+        if ATTR_RGB_COLOR in kwargs:
+            r, g, b = kwargs[ATTR_RGB_COLOR]
+            hex_color = f"{r:02x}{g:02x}{b:02x}"
+            await self.coordinator.evonic.set_zone_color(self._zone_param, hex_color)
+            current_effect = f"{self._effect_prefix}Color"
+
+        if ATTR_EFFECT in kwargs:
+            internal = self._internal_effect(kwargs[ATTR_EFFECT])
+            full_effect = f"{self._effect_prefix}{internal}"
+            await self.coordinator.evonic.set_zone_effect(full_effect)
+            current_effect = full_effect
+
+        if ATTR_BRIGHTNESS in kwargs:
+            await self.coordinator.evonic.set_zone_brightness(
+                self._zone_param, kwargs[ATTR_BRIGHTNESS], current_effect
+            )
+        elif ATTR_EFFECT not in kwargs and ATTR_RGB_COLOR not in kwargs:
+            await self.coordinator.evonic.set_zone_brightness(
+                self._zone_param, 255, current_effect
+            )
+
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        current_effect = getattr(self.coordinator.data.light, self._effect_attr, None)
+        await self.coordinator.evonic.set_zone_brightness(
+            self._zone_param, 0, current_effect
+        )
+        await self.coordinator.async_request_refresh()
+
+
 @callback
 def create_supported_entities(
     coordinator: EvonicCoordinator, async_add_entities: AddEntitiesCallback
@@ -115,7 +261,12 @@ def create_supported_entities(
     supported_features = coordinator.data.info.modules
     entities_to_add: list = [EvonicFireLight(coordinator)]
 
-    if "light_box" in supported_features:
-        entities_to_add.append(EvonicFeatureLight(coordinator))
+    if supported_features:
+        if "light_box" in supported_features:
+            entities_to_add.append(EvonicFeatureLight(coordinator))
+
+        for zone, cfg in _ZONE_CONFIG.items():
+            if cfg["module_key"] in supported_features:
+                entities_to_add.append(EvonicZoneLight(coordinator, zone))
 
     async_add_entities(entities_to_add)

--- a/custom_components/evonic/number.py
+++ b/custom_components/evonic/number.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.components.number import NumberEntity, NumberMode
+
+from .coordinator import EvonicCoordinator
+from .const import DOMAIN
+from .models import EvonicEntity
+
+PARALLEL_UPDATES = 1
+
+_ZONE_NAMES = {
+    "flame": "Flame",
+    "top": "Log",
+    "ember": "FuelBed",
+}
+
+_ZONE_MODULE_KEYS = {
+    "flame": "rgb0",
+    "top": "rgb1",
+    "ember": "rgb2",
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    coordinator: EvonicCoordinator = hass.data[DOMAIN][entry.entry_id]
+    create_supported_entities(coordinator, async_add_entities)
+
+
+class EvonicZoneStrength(EvonicEntity, NumberEntity):
+    """Speed/strength control for a lighting zone."""
+
+    _attr_native_min_value = 0
+    _attr_native_max_value = 240
+    _attr_native_step = 1
+    _attr_mode = NumberMode.SLIDER
+    _attr_icon = "mdi:speedometer"
+
+    def __init__(self, coordinator: EvonicCoordinator, zone: str) -> None:
+        super().__init__(coordinator=coordinator)
+        self._zone_param = zone
+        self._speed_attr = f"{zone}_speed"
+        self._effect_attr = f"{zone}_effect"
+        self._attr_name = f"{_ZONE_NAMES[zone]} Strength"
+        self._attr_unique_id = f"{coordinator.data.info.ssdp}_{zone}_strength"
+
+    @property
+    def available(self) -> bool:
+        return super().available and bool(self.coordinator.data.info.on)
+
+    @property
+    def native_value(self) -> float | None:
+        val = getattr(self.coordinator.data.light, self._speed_attr, None)
+        return float(val) if val is not None else None
+
+    async def async_set_native_value(self, value: float) -> None:
+        current_effect = getattr(self.coordinator.data.light, self._effect_attr, None)
+        await self.coordinator.evonic.set_zone_speed(
+            self._zone_param, int(value), current_effect
+        )
+        await self.coordinator.async_request_refresh()
+
+
+class EvonicFlameMotorSpeed(EvonicEntity, NumberEntity):
+    """Motor speed control for the flame zone."""
+
+    _attr_native_min_value = 0
+    _attr_native_max_value = 1023
+    _attr_native_step = 1
+    _attr_mode = NumberMode.SLIDER
+    _attr_icon = "mdi:engine"
+    _attr_name = "Flame Motor Speed"
+
+    def __init__(self, coordinator: EvonicCoordinator) -> None:
+        super().__init__(coordinator=coordinator)
+        self._attr_unique_id = f"{coordinator.data.info.ssdp}_flame_motor_speed"
+
+    @property
+    def available(self) -> bool:
+        return super().available and bool(self.coordinator.data.info.on)
+
+    @property
+    def native_value(self) -> float | None:
+        val = self.coordinator.data.light.flame_motor_speed
+        return float(val) if val is not None else None
+
+    async def async_set_native_value(self, value: float) -> None:
+        await self.coordinator.evonic.set_flame_motor_speed(int(value))
+        await self.coordinator.async_request_refresh()
+
+
+@callback
+def create_supported_entities(
+    coordinator: EvonicCoordinator, async_add_entities: AddEntitiesCallback
+) -> None:
+    supported_features = coordinator.data.info.modules
+    entities_to_add: list = []
+
+    if supported_features:
+        for zone, module_key in _ZONE_MODULE_KEYS.items():
+            if module_key in supported_features:
+                entities_to_add.append(EvonicZoneStrength(coordinator, zone))
+
+        if "step0" in supported_features:
+            entities_to_add.append(EvonicFlameMotorSpeed(coordinator))
+
+    if entities_to_add:
+        async_add_entities(entities_to_add)

--- a/custom_components/evonic/pyevonic/evonic.py
+++ b/custom_components/evonic/pyevonic/evonic.py
@@ -163,9 +163,49 @@ class Evonic:
         if effect not in self._device.effects.available_effects:
             raise EvonicUnsupportedFeature("Not a valid effect for this device")
 
-        await self._ws_send("voice", effect)
+        await self._ws_send("effect", effect)
         self._device.light.effect = effect
         return await self.get_device()
+
+    async def set_zone_effect(self, effect: str) -> None:
+        """Set a per-zone lighting effect.
+
+        Effect names include the zone prefix, e.g. 'Flame_Spectrum', 'Top_Color', 'Ember_Aurora'.
+        """
+        await self._ws_send("voice", effect)
+
+    async def set_zone_brightness(self, zone: str, brightness: int, current_effect: str | None = None) -> None:
+        """Set brightness for a lighting zone (flame, top, or ember).
+
+        After setting the brightness parameter, re-applies the current effect
+        so the fireplace renders the change.
+        """
+        await self._ws_send("cmd", f"param add {zone}Brightness {brightness}")
+        if current_effect:
+            await self._ws_send("voice", current_effect)
+
+    async def set_zone_color(self, zone: str, hex_color: str) -> None:
+        """Set a custom RGB color for a lighting zone.
+
+        Sends the color parameter and then applies the zone's Color effect.
+        """
+        await self._ws_send("cmd", f"param add {zone}Color {hex_color}")
+        prefix = zone.capitalize()
+        await self._ws_send("voice", f"{prefix}_Color")
+
+    async def set_zone_speed(self, zone: str, speed: int, current_effect: str | None = None) -> None:
+        """Set speed/strength for a lighting zone.
+
+        After setting the speed parameter, re-applies the current effect.
+        """
+        await self._ws_send("cmd", f"param add {zone}Speed {speed}")
+        if current_effect:
+            await self._ws_send("voice", current_effect)
+
+    async def set_flame_motor_speed(self, speed: int) -> None:
+        """Set the flame motor speed."""
+        await self._ws_send("cmd", f"param add flameMotorSpeed {speed}")
+        await self._ws_send("voice", "flameMotorSpeed")
 
     async def toggle_feature_light(self):
         """ Toggles the feature light of an Evonic Fire

--- a/custom_components/evonic/pyevonic/evonic.py
+++ b/custom_components/evonic/pyevonic/evonic.py
@@ -33,6 +33,50 @@ class Evonic:
 
     _close_session: bool = False
     _device: Device | None = None
+    _ws: aiohttp.ClientWebSocketResponse | None = None
+
+    async def _ws_connect(self):
+        """Establish a WebSocket connection to the fireplace on port 81."""
+        if self._ws is not None and not self._ws.closed:
+            return
+
+        if self.session is None:
+            self.session = aiohttp.ClientSession()
+            self._close_session = True
+
+        try:
+            async with async_timeout.timeout(self.request_timeout):
+                self._ws = await self.session.ws_connect(
+                    f"ws://{self.host}:81",
+                    protocols=["arduino"],
+                )
+            LOGGER.debug("WebSocket connected to %s:81", self.host)
+        except asyncio.TimeoutError as exception:
+            raise EvonicConnectionTimeoutError(
+                f"Timeout connecting WebSocket to Evonic device at {self.host}"
+            ) from exception
+        except (aiohttp.ClientError, socket.gaierror, OSError) as exception:
+            raise EvonicConnectionError(
+                f"Error connecting WebSocket to Evonic device at {self.host}"
+            ) from exception
+
+    async def _ws_send(self, msg_type: str, command: str):
+        """Send a JSON command over WebSocket.
+
+        The fireplace expects messages like: {"voice":"Fire_ON"} or {"cmd":"templevel 25"}
+        """
+        await self._ws_connect()
+
+        message = json.dumps({msg_type: command}, separators=(",", ":"))
+        LOGGER.debug("WebSocket send to %s: %s", self.host, message)
+
+        try:
+            await self._ws.send_str(message)
+        except Exception as exception:
+            self._ws = None
+            raise EvonicConnectionError(
+                f"Error sending WebSocket command to Evonic device at {self.host}"
+            ) from exception
 
     async def http_request(self, uri, method, data, host=None, scheme=None):
         """ Sends a http request to the Evonic Fire
@@ -56,7 +100,7 @@ class Evonic:
         if scheme is None:
             scheme = "http"
 
-        url = f"http://{host}{uri}"
+        url = f"{scheme}://{host}{uri}"
 
         if self.session is None:
             LOGGER.debug("No session exists, using ClientSession")
@@ -105,7 +149,7 @@ class Evonic:
         else:
             voice_command = "Fire_ON/OFF"
 
-        return await self.http_request(f"/voice?command={voice_command}", "GET", None)
+        await self._ws_send("voice", voice_command)
 
     async def set_effect(self, effect):
         """ Set an effect on Evonic Fire.
@@ -116,11 +160,10 @@ class Evonic:
         Raises:
             EvonicUnsupportedFeature: Not a valid effect for this device
         """
-        # Check effect is available for this device
         if effect not in self._device.effects.available_effects:
             raise EvonicUnsupportedFeature("Not a valid effect for this device")
 
-        await self.http_request(f"/voice?command={effect}", "GET", None)
+        await self._ws_send("voice", effect)
         self._device.light.effect = effect
         return await self.get_device()
 
@@ -134,7 +177,7 @@ class Evonic:
         if "light_box" not in self._device.info.modules:
             raise EvonicUnsupportedFeature("Feature Light is not supported on this device")
 
-        return await self.http_request(f"/voice?command=Featurelight_NOT", "GET", None)
+        await self._ws_send("voice", "Featurelight_NOT")
 
     async def set_temperature(self, temp):
         """ Sets the heater temperature on an Evonic Fire
@@ -161,7 +204,7 @@ class Evonic:
             if temp not in range(10, 33):
                 raise EvonicError(f"{temp} is not a valid value. Must be between 11 - 32")
 
-        return await self.http_request(f"/cmd?command=templevel {temp}", "GET", None)
+        await self._ws_send("cmd", f"templevel {temp}")
 
     async def heater_power(self, cmd):
         """ Controls the Heater for the Evonic Fire.
@@ -183,7 +226,7 @@ class Evonic:
         else:
             voice_command = "Heater_NOT"
 
-        return await self.http_request(f"/voice?command={voice_command}", "GET", None)
+        await self._ws_send("voice", voice_command)
 
     async def get_device(self):
         """Get the device information.
@@ -242,7 +285,7 @@ class Evonic:
         Information pulled from /options.htm
         """
 
-        paid = None
+        paid_effects = []
 
         if self._device is None:
             raise Exception("No device initialised")
@@ -254,9 +297,10 @@ class Evonic:
                                                None,
                                                "evoflame.co.uk", "https")
             paid = await response.json(content_type=None)
+            paid_effects = paid.get("effect") or []
 
-        except EvonicError as err:
-            raise EvonicConnectionError("Unable to connect to device") from err
+        except Exception as err:
+            LOGGER.warning("Failed to fetch paid effects from evoflame.co.uk, continuing with defaults: %s", err)
 
         configs = self._device.info.configs
         default_effects = ["Vero", "Ignite", "Breathe", "Spectrum", "Embers", "Odyssey", "Aurora", "Red", "Orange",
@@ -278,7 +322,7 @@ class Evonic:
         if configs in ["video"]:
             default_effects = ["Low", "Medium", "High"]
 
-        supported_effects = [*default_effects, *paid.get("effect")]
+        supported_effects = [*default_effects, *paid_effects]
         LOGGER.debug(f"Supported effects {supported_effects}")
 
         self._device.update_from_dict({"available_effects": supported_effects})
@@ -293,7 +337,10 @@ class Evonic:
         return self
 
     async def close(self) -> None:
-        """Close the aiohttp session if it was created internally."""
+        """Close WebSocket and aiohttp session."""
+        if self._ws is not None and not self._ws.closed:
+            await self._ws.close()
+            self._ws = None
         if self._close_session and self.session:
             await self.session.close()
 

--- a/custom_components/evonic/pyevonic/models.py
+++ b/custom_components/evonic/pyevonic/models.py
@@ -68,7 +68,9 @@ class Info:
         )
 
     def update_from_dict(self, data):
-        self.on = data.get("Fire", self.on)
+        fire_val = data.get("Fire", data.get("fire"))
+        if fire_val is not None:
+            self.on = to_int(fire_val)
         self.ssdp = data.get('SSDP', self.ssdp)
         self.ssidAP = data.get('ssidAP', self.ssidAP)
         self.configs = data.get('configs', self.configs)
@@ -105,7 +107,9 @@ class Climate:
     def update_from_dict(self, data):
         self.current_temp = to_int(data.get("temperature", self.current_temp))
         self.target_temp = to_int(data.get("templevel", self.target_temp))
-        self.heating = data.get('Heater', self.heating)
+        heater_val = data.get("Heater", data.get("heater"))
+        if heater_val is not None:
+            self.heating = to_int(heater_val)
         self.fahrenheit = to_int(data.get('fahrenheit', self.fahrenheit))
 
 

--- a/custom_components/evonic/pyevonic/models.py
+++ b/custom_components/evonic/pyevonic/models.py
@@ -116,15 +116,27 @@ class Climate:
 @dataclass
 class Effects:
     available_effects: list | None
+    flame_effects: list | None
+    top_effects: list | None
+    ember_effects: list | None
 
     @staticmethod
     def from_dict(data):
         return Effects(
-            available_effects=data.get('available_effects')
+            available_effects=data.get('available_effects'),
+            flame_effects=data.get('flameList'),
+            top_effects=data.get('topList'),
+            ember_effects=data.get('emberList'),
         )
 
     def update_from_dict(self, data):
         self.available_effects = data.get('available_effects', self.available_effects)
+        if 'flameList' in data:
+            self.flame_effects = data['flameList']
+        if 'topList' in data:
+            self.top_effects = data['topList']
+        if 'emberList' in data:
+            self.ember_effects = data['emberList']
 
 
 @dataclass
@@ -133,27 +145,75 @@ class Light:
     feature_light: Any
     flame_brightness: int
     flame_speed: int
-    fuelbed_brightness: int
-    fuelbed_speed: int
+    flame_effect: str | None
+    flame_color: str | None
+    top_brightness: int
+    top_speed: int
+    top_effect: str | None
+    top_color: str | None
+    ember_brightness: int
+    ember_speed: int
+    ember_effect: str | None
+    ember_color: str | None
+    flame_motor_speed: int
 
     @staticmethod
     def from_dict(data):
         return Light(
             effect=data.get("effect"),
             feature_light=data.get("pinout3"),
-            flame_brightness=to_int(data.get("brightnessRGB0")),
-            flame_speed=to_int(data.get("speedRGB0")),
-            fuelbed_brightness=to_int(data.get("brightnessRGB1")),
-            fuelbed_speed=to_int(data.get("speedRGB1")),
+            flame_brightness=to_int(data.get("brightnessRGB0") or data.get("flameBrightness")),
+            flame_speed=to_int(data.get("speedRGB0") or data.get("flameSpeed")),
+            flame_effect=data.get("flame"),
+            flame_color=data.get("flameColor"),
+            top_brightness=to_int(data.get("brightnessRGB1") or data.get("topBrightness")),
+            top_speed=to_int(data.get("speedRGB1") or data.get("topSpeed")),
+            top_effect=data.get("top"),
+            top_color=data.get("topColor"),
+            ember_brightness=to_int(data.get("emberBrightness")),
+            ember_speed=to_int(data.get("emberSpeed")),
+            ember_effect=data.get("ember"),
+            ember_color=data.get("emberColor"),
+            flame_motor_speed=to_int(data.get("flameMotorSpeed")),
         )
 
     def update_from_dict(self, data):
         self.effect = data.get("effect", self.effect)
         self.feature_light = data.get("pinout3", self.feature_light)
-        self.flame_brightness = to_int(data.get("brightnessRGB0", self.flame_brightness))
-        self.flame_speed = to_int(data.get("speedRGB0", self.flame_speed))
-        self.fuelbed_brightness = to_int(data.get("brightnessRGB1", self.fuelbed_brightness))
-        self.fuelbed_speed = to_int(data.get("speedRGB1", self.fuelbed_speed))
+        if "brightnessRGB0" in data:
+            self.flame_brightness = to_int(data["brightnessRGB0"])
+        if "flameBrightness" in data:
+            self.flame_brightness = to_int(data["flameBrightness"])
+        if "speedRGB0" in data:
+            self.flame_speed = to_int(data["speedRGB0"])
+        if "flameSpeed" in data:
+            self.flame_speed = to_int(data["flameSpeed"])
+        if "flame" in data:
+            self.flame_effect = data["flame"]
+        if "flameColor" in data:
+            self.flame_color = data["flameColor"]
+        if "brightnessRGB1" in data:
+            self.top_brightness = to_int(data["brightnessRGB1"])
+        if "topBrightness" in data:
+            self.top_brightness = to_int(data["topBrightness"])
+        if "speedRGB1" in data:
+            self.top_speed = to_int(data["speedRGB1"])
+        if "topSpeed" in data:
+            self.top_speed = to_int(data["topSpeed"])
+        if "top" in data:
+            self.top_effect = data["top"]
+        if "topColor" in data:
+            self.top_color = data["topColor"]
+        if "emberBrightness" in data:
+            self.ember_brightness = to_int(data["emberBrightness"])
+        if "emberSpeed" in data:
+            self.ember_speed = to_int(data["emberSpeed"])
+        if "ember" in data:
+            self.ember_effect = data["ember"]
+        if "emberColor" in data:
+            self.ember_color = data["emberColor"]
+        if "flameMotorSpeed" in data:
+            self.flame_motor_speed = to_int(data["flameMotorSpeed"])
 
 
 class Device:


### PR DESCRIPTION
## Summary

This PR replaces the HTTP-based command approach with WebSocket communication and adds comprehensive per-zone lighting controls for Evonic fireplaces.

### WebSocket Communication
- All control commands (power, effects, heater) now sent via WebSocket on port 81 with `arduino` protocol
- Background WebSocket listener for real-time state updates (no more 30s polling delay)
- Compact JSON serialization for Arduino parser compatibility
- Graceful reconnection on WebSocket disconnection

### Per-Zone Lighting Controls
- **Flame Light**, **Log Light**, and **FuelBed Light** entities with independent:
  - Brightness control (0-255)
  - Per-zone effect selection (from fireplace's own effect lists via `get effectList`)
  - RGB colour picker for custom colours per zone
- **Strength** number entities per zone (speed slider 0-240)
- **Flame Motor Speed** number entity (0-1023)
- Zone entities auto-created based on module presence (`rgb0`, `rgb1`, `rgb2`, `step0`)

### Bug Fixes
- Fixed `scheme` parameter being ignored in HTTP requests
- Fixed paid effects fetch failure crashing the integration
- Fixed case-sensitivity issues with `Fire`/`fire` and `Heater`/`heater` state keys
- Fixed string `"0"` evaluating as truthy for on/off states
- Fixed effects not applying (changed from `voice` to `effect` key for global effects)

## Test Plan
- [x] Fire on/off from HA
- [x] Heater on/off from HA
- [x] Real-time state updates when fireplace controlled manually
- [x] Global effect selection from Fire Lighting entity
- [x] Per-zone effect selection from zone light entities
- [x] Per-zone brightness control
- [x] Per-zone RGB custom colour picker
- [x] Strength (speed) slider per zone
- [x] Flame motor speed slider
- [x] Integration load/unload with WebSocket cleanup